### PR TITLE
(md:102044) Al ingresar/hacer login a app.tuola.mx a través de Facebook aparece mensaje 

### DIFF
--- a/socialnetworks/facebook/templates/facebook/login_button.html
+++ b/socialnetworks/facebook/templates/facebook/login_button.html
@@ -4,6 +4,9 @@
     <a class="{{ css_class }}" onclick="this.parentNode.submit()">
         <i class="{{ icon_class }}"></i><span>{{ label }}</span>
     </a>
+    {% if is_reconnecting %}
+        <input type="hidden" value="is_reconnecting" name="is_reconnecting"/>
+    {% endif %}
     {% if only_login %}
     <input type="hidden" name="only_login" value="{{ request.get_full_path }}"/>
     {% if 'oauth_error' in request.GET %}

--- a/socialnetworks/facebook/templatetags/facebook.py
+++ b/socialnetworks/facebook/templatetags/facebook.py
@@ -11,8 +11,16 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def facebook_login(context, label=None, css_class=None, icon_class=None,
-                   only_login=False, error_message=None, error_class=None):
+def facebook_login(
+    context,
+    label=None,
+    css_class=None,
+    icon_class=None,
+    only_login=False,
+    error_message=None,
+    error_class=None,
+    is_reconnecting=False
+):
     """
     Renders a 'Sign in with Facebook' button.
 
@@ -39,6 +47,7 @@ def facebook_login(context, label=None, css_class=None, icon_class=None,
     context['icon_class'] = icon_class
     context['error_class'] = error_class
     context['only_login'] = only_login
+    context['is_reconnecting'] = is_reconnecting
 
     context['label'] = (
         label or


### PR DESCRIPTION
# Tareas Relacionadas

[(md:102044) Corrección mensaje de inicio de sesión incorrecto en app.tuola.mx ](http://manoderecha.net/md/index.php/task/102044)
## Descripción del problema

El mensaje de sincronización de la cuenta con Facebook se muestra cada vez que el usuario se conecta usando facebook
## Descripción de la solución

Se modificaron las vistas que muestran el mensaje dentro del sistema, así como se añadió una variable en sesión para enviar la información de reconexión
## Plan de pruebas

Se probabron todos los proyectos dentro de la máquina local. Se adjunta imágenes de los resultados finales.

![captura de pantalla_2015-10-26_14-06-36](https://cloud.githubusercontent.com/assets/1808194/10741713/c8b9b1f2-7bee-11e5-931c-7a8ae571ece7.png)
![captura de pantalla_2015-10-26_14-05-12](https://cloud.githubusercontent.com/assets/1808194/10741710/c8b6cd34-7bee-11e5-8763-9bf0a5ba308f.png)
![captura de pantalla_2015-10-26_13-55-46](https://cloud.githubusercontent.com/assets/1808194/10741711/c8b6d216-7bee-11e5-9bb4-885823c7eb72.png)
![captura de pantalla_2015-10-26_13-51-18](https://cloud.githubusercontent.com/assets/1808194/10741712/c8b7cd42-7bee-11e5-8bfc-e741b7058f71.png)
