### PR TITLE
Fix arguments date time field

### DIFF
--- a/socialnetworks/core/models.py
+++ b/socialnetworks/core/models.py
@@ -26,12 +26,12 @@ class BaseSocialProfile(models.Model):
 
     created_date = models.DateTimeField(
         blank=True, null=True,
-        auto_now=False, auto_now_add=True,
+        auto_now_add=True,
         verbose_name=_('created date')
     )
     last_modified = models.DateTimeField(
         null=True, blank=True,
-        auto_now_add=True, auto_now=True,
+        auto_now=True,
         verbose_name=_('last modified')
     )
 

--- a/socialnetworks/facebook/migrations/0001_initial.py
+++ b/socialnetworks/facebook/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                 ('service_uid', models.CharField(max_length=255, unique=True, null=True, verbose_name='uid', blank=True)),
                 ('oauth_access_token', models.CharField(max_length=255, null=True, verbose_name='OAuth access token', blank=True)),
                 ('created_date', models.DateTimeField(auto_now_add=True, verbose_name='created date', null=True)),
-                ('last_modified', models.DateTimeField(auto_now=True, auto_now_add=True, null=True, verbose_name='last modified')),
+                ('last_modified', models.DateTimeField(auto_now=True, null=True, verbose_name='last modified')),
                 ('oauth_access_token_expires_at', models.DateTimeField(null=True, verbose_name='OAuth access token expires at', blank=True)),
                 ('oauth_refresh_token', models.CharField(max_length=255, null=True, verbose_name='OAuth refresh token', blank=True)),
                 ('user', models.OneToOneField(null=True, blank=True, to=settings.AUTH_USER_MODEL, verbose_name='user')),

--- a/socialnetworks/facebook/south_migrations/0001_initial.py
+++ b/socialnetworks/facebook/south_migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(SchemaMigration):
             ('service_uid', self.gf('django.db.models.fields.CharField')(max_length=255, unique=True, null=True, blank=True)),
             ('oauth_access_token', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
             ('created_date', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, null=True, blank=True)),
-            ('last_modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, auto_now_add=True, null=True, blank=True)),
+            ('last_modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, null=True, blank=True)),
             ('oauth_access_token_expires_at', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
             ('oauth_refresh_token', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
         ))

--- a/socialnetworks/linkedin/migrations/0001_initial.py
+++ b/socialnetworks/linkedin/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                 ('service_uid', models.CharField(max_length=255, unique=True, null=True, verbose_name='uid', blank=True)),
                 ('oauth_access_token', models.CharField(max_length=255, null=True, verbose_name='OAuth access token', blank=True)),
                 ('created_date', models.DateTimeField(auto_now_add=True, verbose_name='created date', null=True)),
-                ('last_modified', models.DateTimeField(auto_now=True, auto_now_add=True, null=True, verbose_name='last modified')),
+                ('last_modified', models.DateTimeField(auto_now=True, null=True, verbose_name='last modified')),
                 ('oauth_access_token_expires_at', models.DateTimeField(null=True, verbose_name='OAuth access token expires at', blank=True)),
                 ('oauth_refresh_token', models.CharField(max_length=255, null=True, verbose_name='OAuth refresh token', blank=True)),
                 ('user', models.OneToOneField(null=True, blank=True, to=settings.AUTH_USER_MODEL, verbose_name='user')),

--- a/socialnetworks/linkedin/south_migrations/0001_initial.py
+++ b/socialnetworks/linkedin/south_migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(SchemaMigration):
             ('service_uid', self.gf('django.db.models.fields.CharField')(max_length=255, unique=True, null=True, blank=True)),
             ('oauth_access_token', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
             ('created_date', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, null=True, blank=True)),
-            ('last_modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, auto_now_add=True, null=True, blank=True)),
+            ('last_modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, null=True, blank=True)),
             ('oauth_access_token_expires_at', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
             ('oauth_refresh_token', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
         ))

--- a/socialnetworks/moves/migrations/0001_initial.py
+++ b/socialnetworks/moves/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                 ('service_uid', models.CharField(max_length=255, unique=True, null=True, verbose_name='uid', blank=True)),
                 ('oauth_access_token', models.CharField(max_length=255, null=True, verbose_name='OAuth access token', blank=True)),
                 ('created_date', models.DateTimeField(auto_now_add=True, verbose_name='created date', null=True)),
-                ('last_modified', models.DateTimeField(auto_now=True, auto_now_add=True, null=True, verbose_name='last modified')),
+                ('last_modified', models.DateTimeField(auto_now=True, null=True, verbose_name='last modified')),
                 ('oauth_access_token_expires_at', models.DateTimeField(null=True, verbose_name='OAuth access token expires at', blank=True)),
                 ('oauth_refresh_token', models.CharField(max_length=255, null=True, verbose_name='OAuth refresh token', blank=True)),
                 ('user', models.OneToOneField(null=True, blank=True, to=settings.AUTH_USER_MODEL, verbose_name='user')),

--- a/socialnetworks/moves/south_migrations/0001_initial.py
+++ b/socialnetworks/moves/south_migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(SchemaMigration):
             ('service_uid', self.gf('django.db.models.fields.CharField')(max_length=255, unique=True, null=True, blank=True)),
             ('oauth_access_token', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
             ('created_date', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, null=True, blank=True)),
-            ('last_modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, auto_now_add=True, null=True, blank=True)),
+            ('last_modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, null=True, blank=True)),
             ('oauth_access_token_expires_at', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
             ('oauth_refresh_token', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
         ))

--- a/socialnetworks/twitter/migrations/0001_initial.py
+++ b/socialnetworks/twitter/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                 ('service_uid', models.CharField(max_length=255, unique=True, null=True, verbose_name='uid', blank=True)),
                 ('oauth_access_token', models.CharField(max_length=255, null=True, verbose_name='OAuth access token', blank=True)),
                 ('created_date', models.DateTimeField(auto_now_add=True, verbose_name='created date', null=True)),
-                ('last_modified', models.DateTimeField(auto_now=True, auto_now_add=True, null=True, verbose_name='last modified')),
+                ('last_modified', models.DateTimeField(auto_now=True, null=True, verbose_name='last modified')),
                 ('oauth_access_token_secret', models.CharField(max_length=255, null=True, verbose_name='OAuth access token secret', blank=True)),
                 ('oauth_request_token', models.CharField(max_length=255, null=True, verbose_name='OAuth request token', blank=True)),
                 ('oauth_request_token_secret', models.CharField(max_length=255, null=True, verbose_name='OAuth request token secret', blank=True)),


### PR DESCRIPTION
# Tareas relacionadas

[Actualizar proyecto de 1.7 a 1.8](http://manoderecha.net/md/index.php/task/117941)
# Descripción del problema

No existe compatibilidad con las versiones superiores a 1.8 de  Django.

Nota:
(jualjiman me comento que te mandara el PR a la rama master, pero como se puede visualizar tenemos algunos commits de más. Si esto causa algún problema te puedo mandar el PR a la Rama v0.5)
# Descripción de la solución

Se modifico los argumentos  de los campos de tipo DateTimeField. Esto permite la compatibilidad con la versión 1.8 de django.
# Plan de pruebas

![tuola-socialnetworks](https://cloud.githubusercontent.com/assets/16564843/18330917/04283980-7521-11e6-8f09-11efbfa9ea02.png)

![tuola-socialnetworks2](https://cloud.githubusercontent.com/assets/16564843/18330923/0c8f1332-7521-11e6-86bf-61d9708c6d80.png)
